### PR TITLE
Fix redundancy with WarpPlugin (KSPI)

### DIFF
--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_AtmIntake.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_AtmIntake.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleResourceIntake],@RESOURCE[IntakeAir]]{
+@PART[*]:HAS[@MODULE[ModuleResourceIntake],@RESOURCE[IntakeAir]]:NEEDS[!WarpPlugin]{
 
 	+MODULE[ModuleResourceIntake]{ 
 	@resourceName = IntakeAtm


### PR DESCRIPTION
KSPI's code causes all intakes for IntakeAir to also generate IntakeAtm. If this is added alongside KSPI, you end up with an extra, redundant intake module, which causes overheating problems for KSPI's atmospheric engines.
