### PR TITLE
Fix node positions on new dual cycles, and first pass on new RP patch

### DIFF
--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/ESTOC/part.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/ESTOC/part.cfg
@@ -5,8 +5,8 @@ PART
 	author = SuicidalInsanity
 	mesh = Model.mu
 	rescaleFactor = 1
-	node_stack_top = 0.0, 0.497789, 0.0 , 0.0, 1.0, 0.0
-	node_stack_bottom = 0.0, -1.309267, 0.0, 0.0, -1.0, 0.0
+	node_stack_top = 0.0, 0.504, 0.0 , 0.0, 1.0, 0.0
+	node_stack_bottom = 0.0, -1.312, 0.0, 0.0, -1.0, 0.0
 	CoMOffset = 0.0, 2.6, 0.0
 	mass = 3.0
 	heatConductivity = 0.06 // half default

--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/MATTOCK/mattock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/MATTOCK/mattock.cfg
@@ -5,7 +5,7 @@ PART
 	author = SuicidalInsanity
 	mesh = Model.mu
 	rescaleFactor = 1
-	node_stack_top = 0.0,0.5124627,0.0 , 0.0, 1.0, 0.0
+	node_stack_top = 0.0,0.506,0.0 , 0.0, 1.0, 0.0
 	node_stack_bottom = 0.0,-1.120129,0.0 , 0.0, -1.0, 0.0
 	CoMOffset = 0.0, 2.6, 0.0
 	mass = 3.5

--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/MATTOCK/mattock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/MATTOCK/mattock.cfg
@@ -148,7 +148,7 @@ PART
 				speed = 0.0 0.25
 				speed = 1.0 1.0
 				localOffset = 0, 0, 4
-				localRotation = 1, 0, 0, 0
+				localRotation = 1, 0, 0, -90
 			}
 			PREFAB_PARTICLE
 			{
@@ -162,7 +162,7 @@ PART
 				speed = 0.0 0.25
 				speed = 1.0 1.0
 				localOffset = 0, 0, 4
-				localRotation = 1, 0, 0, 0
+				localRotation = 1, 0, 0, -90
 			}
 
 		}

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
@@ -1,10 +1,10 @@
 //Dual-cycle engines
-@PART[M2X_ESTOC]:NEEDS[RealPlume,SmokeScreen] //Z0-OM E.S.T.O.C. Engine
+@PART[M2X_ESTOC*]:NEEDS[RealPlume,SmokeScreen] //Z0-OM E.S.T.O.C. Engine
 {
     PLUME
     {
         name = Turbojet
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,-0.3
         fixedScale = 1.2
@@ -15,12 +15,12 @@
     PLUME
     {
         name = Hypergolic-Lower
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         plumePosition = 0,0,0.2
         flarePosition = 0,0,0.4
-        plumeScale = 0.8
-		flareScale = 0.9
+        plumeScale = 0.7
+		flareScale = 0.8
         energy = 0.7
         speed = 1
 		emissionMult = 1.0
@@ -35,14 +35,36 @@
         %powerEffectName = Hypergolic-Lower
     }
 }
-@PART[M2X_MATTOCK]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
+@PART[M2X_MATTOCKv2]FOR:[Mk2Expansion]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
 {
     PLUME
     {
-        name = Turbojet
-        transNEEDSmName = thrustTransNEEDSm
+        name = TurbojetC
+        transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,-0.3
+        localPosition = 0,0.0,-0.3
+        fixedScale = 0.5
+        energy = 0.8
+        speed = 1
+		emissionMult = 1.0
+    }
+    PLUME
+    {
+        name = TurbojetL
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0.2,0.0,-0.3
+        fixedScale = 0.5
+        energy = 0.8
+        speed = 1
+		emissionMult = 1.0
+    }
+	PLUME
+    {
+        name = TurbojetR
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = -0.2,0.0,-0.3
         fixedScale = 0.5
         energy = 0.8
         speed = 1
@@ -51,24 +73,84 @@
     PLUME
     {
         name = Hypergolic-Lower
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
-        plumePosition = 0,0,0.0
-        flarePosition = 0,0,0.7
+        plumePosition = 0,0.0,0.0
+        flarePosition = 0,0,0.5
         plumeScale = 0.5
 		flareScale = 0.6
         energy = 1
         speed = 1
 		emissionMult = 1.0
     }
+	PLUME
+    {
+        name = Hypergolic-LowerL
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        plumePosition = 0.2,0.0,0.0
+        flarePosition = 0,0,0.5
+        plumeScale = 0.5
+		flareScale = 0.6
+        energy = 1
+        speed = 1
+		emissionMult = 1.0
+    }
+    PLUME
+    {
+        name = Hypergolic-LowerR
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        plumePosition = -0.2,0.0,0.0
+        flarePosition = 0,0,0.5
+        plumeScale = 0.5
+		flareScale = 0.6
+        energy = 1
+        speed = 1
+		emissionMult = 1.0
+    }
+}
+@PART[M2X_MATTOCKv2]FOR:[zMk2Expansion]:NEEDS[RealPlume,SmokeScreen]
+{
+    @EFFECTS
+    {
+        @Turbojet
+        {
+            |_ = CombinedTurbojet
+        }
+        @TurbojetL
+        {
+            |_ = CombinedTurbojet
+        }
+		@TurbojetR
+        {
+            |_ = CombinedTurbojet
+        }
+    }
+    @EFFECTS
+    {
+        @Hypergolic-Lower
+        {
+            |_ = CombinedHypergolic
+        }
+        @Hypergolic-LowerL
+        {
+            |_ = CombinedHypergolic
+        }
+		@Hypergolic-LowerR
+        {
+            |_ = CombinedHypergolic
+        }
+    }
+
     @MODULE[ModuleEngines*],0
     {
-        %powerEffectName = Turbojet
+        %powerEffectName = CombinedTurbojet
         %spoolEffectName = Turbojet-Spool
     }
     @MODULE[ModuleEngines*],1
     {
-        %powerEffectName = Hypergolic-Lower
+        %powerEffectName = CombinedHypergolic
     }
 }
 //air-augmented rockets
@@ -77,7 +159,7 @@
     PLUME
     {
         name = Solid-Upper
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
@@ -92,7 +174,7 @@
     PLUME
     {
         name = Solid-Lower
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
@@ -118,7 +200,7 @@
     PLUME
     {
         name = Solid-Upper
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
@@ -133,7 +215,7 @@
     PLUME
     {
         name = Solid-Lower
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,0.25
         plumePosition = 0,0,0.7
@@ -159,7 +241,7 @@
     PLUME
     {
         name = Turbojet
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,-0.3
         fixedScale = 0.9
@@ -170,7 +252,7 @@
     PLUME
     {
         name = Kerolox-Upper
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,0.45
         plumePosition = 0,0,0.0
@@ -196,7 +278,7 @@ Rocket Engines
     PLUME
     {
         name = Ion-Xenon-Gridded
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.5
         fixedScale = 0.95
@@ -213,7 +295,7 @@ Rocket Engines
     PLUME
     {
         name = Hydrogen-NTR
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,-.4
         fixedScale = 1
@@ -231,7 +313,7 @@ Rocket Engines
     PLUME
     {
         name = Hypergolic-OMS-White
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         flarePosition = 0,0,-.2
         plumePositiono = 0,0,-.2 
@@ -253,7 +335,7 @@ Rocket Engines
     PLUME
     {
         name = Turbofan
-        transNEEDSmName = thrustTransNEEDSm
+        transformName = thrustTransform
         localRotation = 0,0,0
         localPosition = 0,0,-1
         fixedScale = 1.3

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
@@ -19,8 +19,8 @@
         localRotation = 0,0,0
         plumePosition = 0,0,0.2
         flarePosition = 0,0,0.4
-        plumeScale = 0.7
-		flareScale = 0.8
+        plumeScale = 0.8
+		flareScale = 0.9
         energy = 0.7
         speed = 1
 		emissionMult = 1.0
@@ -35,36 +35,14 @@
         %powerEffectName = Hypergolic-Lower
     }
 }
-@PART[M2X_MATTOCKv2]:FOR[Mk2Expansion]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
+@PART[M2X_MATTOCK]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
 {
     PLUME
     {
-        name = TurbojetC
+        name = Turbojet
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0.0,-0.3
-        fixedScale = 0.5
-        energy = 0.8
-        speed = 1
-		emissionMult = 1.0
-    }
-    PLUME
-    {
-        name = TurbojetL
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = 0.2,0.0,-0.3
-        fixedScale = 0.5
-        energy = 0.8
-        speed = 1
-		emissionMult = 1.0
-    }
-	PLUME
-    {
-        name = TurbojetR
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        localPosition = -0.2,0.0,-0.3
+        localPosition = 0,0,-0.3
         fixedScale = 0.5
         energy = 0.8
         speed = 1
@@ -75,82 +53,22 @@
         name = Hypergolic-Lower
         transformName = thrustTransform
         localRotation = 0,0,0
-        plumePosition = 0,0.0,0.0
-        flarePosition = 0,0,0.5
+        plumePosition = 0,0,0.0
+        flarePosition = 0,0,0.7
         plumeScale = 0.5
 		flareScale = 0.6
         energy = 1
         speed = 1
 		emissionMult = 1.0
     }
-	PLUME
-    {
-        name = Hypergolic-LowerL
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        plumePosition = 0.2,0.0,0.0
-        flarePosition = 0,0,0.5
-        plumeScale = 0.5
-		flareScale = 0.6
-        energy = 1
-        speed = 1
-		emissionMult = 1.0
-    }
-    PLUME
-    {
-        name = Hypergolic-LowerR
-        transformName = thrustTransform
-        localRotation = 0,0,0
-        plumePosition = -0.2,0.0,0.0
-        flarePosition = 0,0,0.5
-        plumeScale = 0.5
-		flareScale = 0.6
-        energy = 1
-        speed = 1
-		emissionMult = 1.0
-    }
-}
-@PART[M2X_MATTOCKv2]:FOR[zMk2Expansion]:NEEDS[RealPlume,SmokeScreen]
-{
-    @EFFECTS
-    {
-        @Turbojet
-        {
-            |_ = CombinedTurbojet
-        }
-        @TurbojetL
-        {
-            |_ = CombinedTurbojet
-        }
-		@TurbojetR
-        {
-            |_ = CombinedTurbojet
-        }
-    }
-    @EFFECTS
-    {
-        @Hypergolic-Lower
-        {
-            |_ = CombinedHypergolic
-        }
-        @Hypergolic-LowerL
-        {
-            |_ = CombinedHypergolic
-        }
-		@Hypergolic-LowerR
-        {
-            |_ = CombinedHypergolic
-        }
-    }
-
     @MODULE[ModuleEngines*],0
     {
-        %powerEffectName = CombinedTurbojet
+        %powerEffectName = Turbojet
         %spoolEffectName = Turbojet-Spool
     }
     @MODULE[ModuleEngines*],1
     {
-        %powerEffectName = CombinedHypergolic
+        %powerEffectName = Hypergolic-Lower
     }
 }
 //air-augmented rockets

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
@@ -35,7 +35,7 @@
         %powerEffectName = Hypergolic-Lower
     }
 }
-@PART[M2X_MATTOCKv2]FOR:[Mk2Expansion]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
+@PART[M2X_MATTOCKv2]:FOR[Mk2Expansion]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
 {
     PLUME
     {
@@ -110,7 +110,7 @@
 		emissionMult = 1.0
     }
 }
-@PART[M2X_MATTOCKv2]FOR:[zMk2Expansion]:NEEDS[RealPlume,SmokeScreen]
+@PART[M2X_MATTOCKv2]:FOR[zMk2Expansion]:NEEDS[RealPlume,SmokeScreen]
 {
     @EFFECTS
     {


### PR DESCRIPTION
The nodes on the new dual cycle engines were slightly off, visibly clipping/z-fighting on the estoc, and a visible gap on the mattock.

Fixed a search/replace messing up the realplume patch, and apply it to the v2 estoc. the mattock ideally needs more thrust transforms to create plumes out of each nozzle, or more realplume config magic