### PR TITLE
Rework the Pluto engine Kerbal Atomics patch to bring it more in line with the LV-N under Kerbal Atomics (x1.5)

### DIFF
--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/Pluto/part.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/Engines/Pluto/part.cfg
@@ -50,7 +50,7 @@ PART
 	{
 		name = ModuleEnginesFX
 		thrustVectorTransformName = thrustTransform
-		runningEffectName = running_closed
+		runningEffectName = mode_LF
 		exhaustDamage = True
 		ignitionThreshold = 0.1
 		minThrust = 0
@@ -58,6 +58,7 @@ PART
 		heatProduction = 332
 		fxOffset = 0, 0, 0
 		EngineType = Nuclear
+		engineID = LF
 		PROPELLANT
 		{
 			name = LiquidFuel
@@ -86,7 +87,7 @@ PART
 	}	
 	EFFECTS
 	{
-		running_closed
+		mode_LF
 		{
 			AUDIO
 			{

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_KA.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_KA.cfg
@@ -1,12 +1,107 @@
 // Kerbal Atomics Patch
-@PART[M2X_Pluto]:NEEDS[KerbalAtomics,!KSPIntegration]
+
+// adapted from KerbalAtomics, changing the part into a dual mode
+// LF / LH2 engine, with appropriate balancing.
+@PART[M2X_Pluto]:NEEDS[KerbalAtomics,!KSPIntegration,!NTRsUseLF]
 {
-	@MODULE[ModuleEnginesFX]  
+	// kerbalAtomics LV-N is 21% lighter
+	@mass -= 0.96
+
+	MODULE
 	{
+		name = MultiModeEngine
+		primaryEngineID = LF
+		secondaryEngineID = LH2
+    	primaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LF
+    	secondaryEngineModeDisplayName = #LOC_KerbalAtomics_Multimode_LH2
+	}
+
+	// this should be used in both modes
+	@MODULE[ModuleAlternator]
+	{
+		preferMultiMode = true
+	}
+
+	// this should be used in both modes
+	@MODULE[FXModuleAnimateThrottle]
+	{
+		preferMultiMode = true
+	}
+
+	// reduce the LF performance to match the LV-N under kerbal atomics
+	@MODULE[ModuleEnginesFX]
+	{
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 600
+			key = 1 185
+			key = 2 0.001
+		}
+	}
+
+	// and add a LH2 mode to match the LV-N under kerbal atomics
+	// by copying the LF one
+	$MODULE[ModuleEnginesFX]:HAS[#engineID[LF]]
+	{
+		@engineID = LH2
+		@runningEffectName = mode_LH2
+
 		@PROPELLANT[LiquidFuel] 
 		{
-			@name =  LqdHydrogen
-			@ratio = 1.0  
+			@name = LqdHydrogen
+			@ratio = 1.0
+		}
+
+		!atmosphereCurve {}
+		atmosphereCurve
+		{
+			key = 0 900
+			key = 1 400
+			key = 2 50
+			key = 10 1
+		}
+	}
+
+	@EFFECTS
+	{
+		// this is just a copy of the mode_LF
+		mode_LH2
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+			PREFAB_PARTICLE
+			{
+				prefabName = fx_smokeTrail_light
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.25
+				speed = 1.0 1.0
+				localOffset = 0, 0, 1
+				localRotation = 1, 0, 0, -90
+			}
+			MODEL_MULTI_PARTICLE
+			{
+				modelName = Mk2Expansion/FX/Pluto_Plume
+				transformName = thrustTransform
+				emission = 0.0 0.0
+				emission = 0.05 0.0
+				emission = 0.075 0.25
+				emission = 1.0 1.25
+				speed = 0.0 0.5
+				speed = 0.2 0.8
+			}
 		}
 	}
 }

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
@@ -210,6 +210,17 @@ Rocket Engines
 }
 @PART[M2X_Pluto]:NEEDS[RealPlume,SmokeScreen] //AT-2 Pluto Atomic Rocket Motor
 {
+    PLUME:NEEDS[KerbalAtomics,!KSPIntegration,!NTRsUseLF]
+    {
+        name = Nuclear_SolidCore_LOX
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.4
+        fixedScale = 0.75
+        energy = 1.5
+        speed = 4.5
+		emissionMult = 2
+    }
     PLUME
     {
         name = Hydrogen-NTR
@@ -219,9 +230,13 @@ Rocket Engines
         fixedScale = 1
         energy = 1.5
         speed = 1.5
-		emissionMult = 2
+        emissionMult = 2
     }
-    @MODULE[ModuleEngines*]
+    @MODULE[ModuleEngines*],0
+    {
+        %powerEffectName = Nuclear_SolidCore_LOX
+    }
+    @MODULE[ModuleEngines*],1:NEEDS[KerbalAtomics,!KSPIntegration,!NTRsUseLF]
     {
         %powerEffectName = Hydrogen-NTR
     }

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_RealPlumeStock.cfg
@@ -1,5 +1,5 @@
 //Dual-cycle engines
-@PART[M2X_ESTOC*]:NEEDS[RealPlume,SmokeScreen] //Z0-OM E.S.T.O.C. Engine
+@PART[M2X_ESTOC*]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //Z0-OM E.S.T.O.C. Engine
 {
     PLUME
     {
@@ -10,7 +10,7 @@
         fixedScale = 1.2
         energy = 0.8
         speed = 1.2
-		emissionMult = 1.0
+        emissionMult = 1.0
     }
     PLUME
     {
@@ -20,10 +20,10 @@
         plumePosition = 0,0,0.2
         flarePosition = 0,0,0.4
         plumeScale = 0.8
-		flareScale = 0.9
+        flareScale = 0.9
         energy = 0.7
         speed = 1
-		emissionMult = 1.0
+        emissionMult = 1.0
     }
     @MODULE[ModuleEngines*],0
     {
@@ -35,7 +35,7 @@
         %powerEffectName = Hypergolic-Lower
     }
 }
-@PART[M2X_MATTOCK]:NEEDS[RealPlume,SmokeScreen] //X-44 M.A.T.T.O.C.K. Engine
+@PART[M2X_MATTOCK]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //X-44 M.A.T.T.O.C.K. Engine
 {
     PLUME
     {
@@ -46,7 +46,7 @@
         fixedScale = 0.5
         energy = 0.8
         speed = 1
-		emissionMult = 1.0
+        emissionMult = 1.0
     }
     PLUME
     {
@@ -56,10 +56,10 @@
         plumePosition = 0,0,0.0
         flarePosition = 0,0,0.7
         plumeScale = 0.5
-		flareScale = 0.6
+        flareScale = 0.6
         energy = 1
         speed = 1
-		emissionMult = 1.0
+        emissionMult = 1.0
     }
     @MODULE[ModuleEngines*],0
     {
@@ -82,12 +82,12 @@
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
         flareScale = 1
-		plumeScale = 0.25
-		smokeScale = .12
-		slagScale = 0.25
+        plumeScale = 0.25
+        smokeScale = .12
+        slagScale = 0.25
         energy = 1
         speed = 1
-		emissionMult = 0.5
+        emissionMult = 0.5
     }
     PLUME
     {
@@ -97,12 +97,12 @@
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
         flareScale = 1
-		plumeScale = 0.25
-		smokeScale = .12
-		slagScale = 0.25
+        plumeScale = 0.25
+        smokeScale = .12
+        slagScale = 0.25
         energy = 1
         speed = 1
-		emissionMult = 0.5
+        emissionMult = 0.5
     }
     @MODULE[ModuleEngines*],0
     {
@@ -123,12 +123,12 @@
         flarePosition = 0,0,0.1
         plumePosition = 0,0,0.7
         flareScale = 1
-		plumeScale = 0.5
-		smokeScale = 0.25
-		slagScale = 0.25
+        plumeScale = 0.5
+        smokeScale = 0.25
+        slagScale = 0.25
         energy = 1
         speed = 1
-		emissionMult = 0.5
+        emissionMult = 0.5
     }
     PLUME
     {
@@ -138,12 +138,12 @@
         flarePosition = 0,0,0.25
         plumePosition = 0,0,0.7
         flareScale = 1.5
-		plumeScale = 0.33
-		slagScale = 0.5
-		smokeScale = 0.25
+        plumeScale = 0.33
+        slagScale = 0.5
+        smokeScale = 0.25
         energy = 1
         speed = 1
-		emissionMult = 0.5
+        emissionMult = 0.5
     }
     @MODULE[ModuleEngines*],0
     {
@@ -154,7 +154,7 @@
         %powerEffectName = Solid-Lower
     }
 }
-@PART[M2X_AugmentedRocket]:NEEDS[RealPlume,SmokeScreen] //SP-x4 Sledgehammer
+@PART[M2X_AugmentedRocket]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //SP-x4 Sledgehammer
 {
     PLUME
     {
@@ -165,7 +165,7 @@
         fixedScale = 0.9
         energy = 0.8
         speed = 1
-		emissionMult = 1.0
+        emissionMult = 1.0
     }
     PLUME
     {
@@ -174,11 +174,11 @@
         localRotation = 0,0,0
         flarePosition = 0,0,0.45
         plumePosition = 0,0,0.0
-		plumeScale = 0.25
+        plumeScale = 0.25
         flareScale = 0.45
         energy = 0.8
         speed = 0.4
-	}
+    }
     @MODULE[ModuleEngines*],0
     {
         %powerEffectName = Turbojet
@@ -191,7 +191,7 @@
 }
 //
 Rocket Engines
-@PART[M2X_IonEngine]:NEEDS[RealPlume,SmokeScreen] //EEP-13 Spirit Ion Thruster
+@PART[M2X_IonEngine]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //EEP-13 Spirit Ion Thruster
 {
     PLUME
     {
@@ -208,7 +208,7 @@ Rocket Engines
         %powerEffectName = Ion-Xenon-Gridded
     }
 }
-@PART[M2X_Pluto]:NEEDS[RealPlume,SmokeScreen] //AT-2 Pluto Atomic Rocket Motor
+@PART[M2X_Pluto]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //AT-2 Pluto Atomic Rocket Motor
 {
     PLUME:NEEDS[KerbalAtomics,!KSPIntegration,!NTRsUseLF]
     {
@@ -219,7 +219,7 @@ Rocket Engines
         fixedScale = 0.75
         energy = 1.5
         speed = 4.5
-		emissionMult = 2
+        emissionMult = 2
     }
     PLUME
     {
@@ -241,7 +241,7 @@ Rocket Engines
         %powerEffectName = Hydrogen-NTR
     }
 }
-@PART[M2X_OMSpod]:NEEDS[RealPlume,SmokeScreen] //mx2 Stationkeeper OMS
+@PART[M2X_OMSpod]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //mx2 Stationkeeper OMS
 {
     PLUME
     {
@@ -250,11 +250,11 @@ Rocket Engines
         localRotation = 0,0,0
         flarePosition = 0,0,-.2
         plumePositiono = 0,0,-.2 
-        	plumeScale = 0.4
+            plumeScale = 0.4
         flareScale = 0.2
         energy = 1.5
         speed = 1.5
-		emissionMult = 2
+        emissionMult = 2
     }
     @MODULE[ModuleEngines*]
     {
@@ -263,7 +263,7 @@ Rocket Engines
 }
 
 //Jets
-@PART[M2X_HeavyVTOL]:NEEDS[RealPlume,SmokeScreen] //H-VR J.Edgar Hover engine
+@PART[M2X_HeavyVTOL]:NEEDS[RealPlume,SmokeScreen,!Waterfall] //H-VR J.Edgar Hover engine
 {
     PLUME
     {
@@ -274,7 +274,7 @@ Rocket Engines
         fixedScale = 1.3
         energy = 1
         speed = 1
-		emissionMult = 1
+        emissionMult = 1
     }
     @MODULE[ModuleEngines*]
     {

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_Waterfall/Mk2X_Waterfall.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/M2X_Waterfall/Mk2X_Waterfall.cfg
@@ -1528,7 +1528,20 @@ MODULE
   !EFFECTS {}
   EFFECTS
 	{
-		running_closed
+		mode_LF
+		{
+			AUDIO
+			{
+				channel = Ship
+				clip = sound_rocket_hard
+				volume = 0.0 0.0
+				volume = 1.0 1.0
+				pitch = 0.0 0.2
+				pitch = 1.0 1.0
+				loop = true
+			}
+		}
+		mode_LH2
 		{
 			AUDIO
 			{
@@ -1571,16 +1584,10 @@ MODULE
 		}
 	}
   
-  @MODULE[ModuleEngines*]
-   {
-    @name = ModuleEnginesFX
-	%runningEffectName = running_closed
-   }
-  
   MODULE
   {
     name = ModuleWaterfallFX
-    moduleID = nukeFX
+    moduleID = nukeFXLF
 
     CONTROLLER
     {
@@ -1591,8 +1598,8 @@ MODULE
     {
       name = throttle
       linkedTo = throttle
-	  engineID = basicEngine
-	  responseRateUp = 0.03
+	    engineID = LF
+	    responseRateUp = 0.03
       responseRateDown = 0.2
     }
 	
@@ -1621,9 +1628,68 @@ MODULE
     {
       templateName = waterfall-ntr-lh2-1
       overrideParentTransform = thrustTransform
-      scale = 1.48,1.48,1.35
+      scale = 1.48,1.48,1.05
       rotation = 0,0,0
-      position = 0,0,-1.12
+      position = 0,0,-0.87
+    }
+	
+   TEMPLATE
+    {
+      templateName = waterfall-nozzle-glow-white-1
+      overrideParentTransform = thrustTransform
+      scale = 0.9,0.9,1.2
+      rotation = 0,0,0
+      position = 0,0,0.05
+    }
+  }
+  
+  MODULE:NEEDS[KerbalAtomics,!KSPIntegration,!NTRsUseLF]
+  {
+    name = ModuleWaterfallFX
+    moduleID = nukeFXLH2
+
+    CONTROLLER
+    {
+      name = atmosphereDepth
+      linkedTo = atmosphere_density
+    }
+    CONTROLLER
+    {
+      name = throttle
+      linkedTo = throttle
+	    engineID = LH2
+	    responseRateUp = 0.03
+      responseRateDown = 0.2
+    }
+	
+	CONTROLLER
+	{
+		name = random1
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 8
+		seed = 15
+	}
+	CONTROLLER
+	{
+		name = random2
+		linkedTo = random
+		noiseType = perlin
+		scale = 0.5
+		minimum = -0.5
+		speed = 10
+		seed = 15
+	}
+	
+   TEMPLATE
+    {
+      templateName = waterfall-ntr-lh2-1
+      overrideParentTransform = thrustTransform
+      scale = 1.48,1.48,1.65
+      rotation = 0,0,0
+      position = 0,0,-1.37
     }
 	
    TEMPLATE

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_NFE_Functionality.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_NFE_Functionality.cfg
@@ -1,8 +1,8 @@
 @PART[M2X_Pluto]:NEEDS[NearFutureElectrical,!KSPIntegration,!SystemHeat]
 //adds localization strings to plug into NFE's localization framework
 {
-@mass = 3.89665
-@cost = 65125
+	@mass -= 0.1646
+
 	!MODULE[ModuleActiveRadiator] {}
 	!MODULE[ModuleAlternator] {}
 MODULE
@@ -99,14 +99,14 @@ MODULE
 	RESOURCE
 	{
 		name = EnrichedUranium
-		amount = 55
-		maxAmount = 55
+		amount = 15
+		maxAmount = 15
 	}
 	RESOURCE
 	{
 		name = DepletedFuel
 		amount = 0
-		maxAmount = 55
+		maxAmount = 15
 	}
 	MODULE
 	{

--- a/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_SystemHeat.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Patches/Mk2X_SystemHeat.cfg
@@ -1,7 +1,8 @@
 @PART[M2X_Pluto]:NEEDS[SystemHeat]
 //adds localization strings to plug into NFE's localization framework
 {
-	@mass = 3.89665
+	@mass -= 0.1646
+
   	!MODULE[ModuleSystemHeatEngine] {}
   	!MODULE[ModuleAlternator] {}
 	!MODULE[ModuleUpdateOverride] {}
@@ -13,7 +14,7 @@
   	!MODULE[ModuleOverheatDisplay] {}
   	!MODULE[ModuleResourceConverter] {}
 
-  	@MODULE[ModuleEnginesFX] 
+  	@MODULE[ModuleEnginesFX],*
 	{
     		@heatProduction = 0
   	}
@@ -83,16 +84,16 @@
 	!RESOURCE[DepletedFuel] {}
 	RESOURCE
 	{
-		 name = DepletedFuel
-		 amount = 0
-		 maxAmount = 55
+		name = DepletedFuel
+		amount = 0
+		maxAmount = 15
 	}
 	!RESOURCE[EnrichedUranium] {}
 	RESOURCE
 	{
-		 name = EnrichedUranium
-		 amount = 55
-		 maxAmount = 55
+		name = EnrichedUranium
+		amount = 15
+		maxAmount = 15
 	}
 	
 	@MODULE[ModuleActiveRadiator]
@@ -144,20 +145,6 @@
 			key = 0 0
 			key = 1 1
 		}
-	}
-	!RESOURCE[DepletedFuel] {}
-	RESOURCE
-	{
-		 name = DepletedFuel
-		 amount = 0
-		 maxAmount = 55
-	}
-	!RESOURCE[EnrichedUranium] {}
-	RESOURCE
-	{
-		 name = EnrichedUranium
-		 amount = 55
-		 maxAmount = 55
 	}
 
 }


### PR DESCRIPTION
I was trying out this mod and liking it, but found the Pluto really underwelming compared to the LV-N for my spaceplanes. This was mainly because it only runs on liquid hydrogen, while the NERV under kerbal atomics can also run on liquid fuel (for a reduced ISP of 600s). Meanwhile the Pluto requires hydrogen fuel, which is is practically impossible to pack sufficient amounts of into the MK2 form factor due to its low density.

This patch ensures the Pluto is basically 1.5x a NERV again when Kerbal Atomics is used in all aspects. I also adjusted the RealPlume / Waterfall configuration to match the dual mode behaviour (although these were mostly minor changes). Small fixes were made to the Systemheat / Near Future Electrical configuration to match (mainly reducing the amount of Uranium from 55 to 15 to match the NERV's 10).

This is my first foray into KSP modding. I've tested this on bare KSP, with Systemheat, RealPlume and Waterfall, but as I was mostly learning while doing this some mistakes might've slipped in.

Edit: also sorted out that Parts with waterfall definitions don't have the realplume definitions used as well.