### PR TITLE
Fix tricoupler centre nodes disappearing sometimes.

### DIFF
--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/FuelTank/LinearTricoupler/part.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/FuelTank/LinearTricoupler/part.cfg
@@ -5,9 +5,9 @@ PART
 	author = SuicidalInsanity
 	rescaleFactor = 1.0
 	node_stack_top = 0.0, 0.8306551, 0.0, 0.0, 1.0, 0.0
-	node_stack_bottom = 0.0, -0.9028862, 0.0, 0.0, -1.0, 0.0
-	node_stack_bottom_01 = 1.223489, -0.9028862, 0.0, 0.0, -1.0, 0.0
-	node_stack_bottom_02 = -1.223489, -0.9028862, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom03 = 0.0, -0.9028862, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom01 = 1.223489, -0.9028862, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom02 = -1.223489, -0.9028862, 0.0, 0.0, -1.0, 0.0
 	node_attach = 1.25, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	TechRequired = advAerodynamics
 	entryCost = 21700

--- a/Mk2Expansion/GameData/Mk2Expansion/Parts/FuelTank/Tricoupler/part.cfg
+++ b/Mk2Expansion/GameData/Mk2Expansion/Parts/FuelTank/Tricoupler/part.cfg
@@ -5,9 +5,9 @@ PART
 	author = SuicidalInsanity
 	rescaleFactor = 1.0
 	node_stack_top = 0.0, 0.557218, 0.0, 0.0, 1.0, 0.0
-	node_stack_bottom = 0.0, -0.589946, 0.0, 0.0, -1.0, 0.0
-	node_stack_bottom_01 = 0.9375, -0.589946, 0.0, 0.0, -1.0, 0.0
-	node_stack_bottom_02 = -0.9375, -0.589946, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom03 = 0.0, -0.589946, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom01 = 0.9375, -0.589946, 0.0, 0.0, -1.0, 0.0
+	node_stack_bottom02 = -0.9375, -0.589946, 0.0, 0.0, -1.0, 0.0
 	node_attach = 1.25, 0.0, 0.0, 0.0, 1.0, 0.0, 1
 	TechRequired = advAerodynamics
 	entryCost = 21700


### PR DESCRIPTION
Test case: place random object in editor. place two tricouplers in symmetry on it. Place objects on all nodes on the tricoupler. launch this device and revert to the editor. Inspecting the drag cube on the tricoupler shows very high drag on the back face, and after removing the part mounted on the centre node, no node is visible on the part.

I'm not sure why these changes fix this. I simply changed the part to use the same node naming as the stock 1 to 3 adapters, and tried to keep the numbers consistent.